### PR TITLE
Conformance tests: improve awaitServiceImport

### DIFF
--- a/conformance/clusterip_service_dns.go
+++ b/conformance/clusterip_service_dns.go
@@ -44,11 +44,10 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 
 		serviceImports := []*v1alpha1.ServiceImport{}
 		for _, client := range clients {
-			serviceImport := t.awaitServiceImport(&client, t.helloService.Name, func(serviceImport *v1alpha1.ServiceImport) bool {
-				return len(serviceImport.Spec.IPs) > 0
-			})
-			Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found on cluster %q", client.name)
-			Expect(serviceImport.Spec.IPs).ToNot(BeEmpty(), "ServiceImport on cluster %q does not contain an IP", client.name)
+			serviceImport := t.awaitServiceImport(&client, t.helloService.Name, false,
+				func(g Gomega, serviceImport *v1alpha1.ServiceImport) {
+					g.Expect(serviceImport.Spec.IPs).ToNot(BeEmpty(), "ServiceImport on cluster %q does not contain an IP", client.name)
+				})
 			serviceImports = append(serviceImports, serviceImport)
 		}
 

--- a/conformance/service_import.go
+++ b/conformance/service_import.go
@@ -33,6 +33,7 @@ var (
 	_ = Describe("", Label(ClusterIPLabel), testClusterIPServiceImport)
 	_ = Describe("", Label(HeadlessLabel), testHeadlessServiceImport)
 	_ = Describe("", Label(ExternalNameLabel), testExternalNameService)
+	_ = Describe("", testServiceTypeConflict)
 )
 
 func testGeneralServiceImport() {
@@ -324,5 +325,33 @@ func testExternalNameService() {
 		t.awaitServiceExportCondition(&clients[0], v1alpha1.ServiceExportValid, metav1.ConditionFalse)
 		t.ensureNoServiceImport(&clients[0], helloServiceName,
 			"the ServiceImport should not exist for an ExternalName service")
+	})
+}
+
+func testServiceTypeConflict() {
+	t := newTwoClusterTestDriver(newTestDriver())
+
+	BeforeEach(func() {
+		t.helloService2.Spec.ClusterIP = corev1.ClusterIPNone
+	})
+
+	JustBeforeEach(func() {
+		t.createServiceExport(&clients[0], newHelloServiceExport())
+	})
+
+	Specify("A service exported on two clusters with conflicting headlessness should apply the conflict resolution policy and "+
+		"report a Conflict condition on the ServiceExport", Label(RequiredLabel), func() {
+		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#headlessness")
+
+		t.awaitServiceExportCondition(&clients[1], v1alpha1.ServiceExportConflict, metav1.ConditionTrue)
+
+		for i := range clients {
+			serviceImport := t.awaitServiceImport(&clients[i], helloServiceName, true, nil)
+			Expect(serviceImport).NotTo(BeNil(), reportNonConformant(fmt.Sprintf("ServiceImport was not found on cluster %q",
+				clients[i].name)))
+
+			Expect(serviceImport.Spec.Type).To(Equal(v1alpha1.ClusterSetIP), reportNonConformant(
+				fmt.Sprintf("ServiceImport on cluster %q has type %q", clients[i].name, serviceImport.Spec.Type)))
+		}
 	})
 }


### PR DESCRIPTION
We can improve it by utilizing the form of 'Eventually' that accepts a function that that takes a single Gomega argument which is used to make assertions. 'Eventually' succeeds only if all the assertions in the polled function pass. This is simpler than first polling to find the ServiceImport based on initial checks then making separate assertions to provide better error output that typically overlap with the initial checks.