### PR TITLE
Ensure first cluster exports service before second cluster

### DIFF
--- a/conformance/clusterip_service_dns.go
+++ b/conformance/clusterip_service_dns.go
@@ -32,10 +32,6 @@ import (
 var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 	t := newTestDriver()
 
-	JustBeforeEach(func() {
-		t.createServiceExport(&clients[0], newHelloServiceExport())
-	})
-
 	Specify("A DNS lookup of the <service>.<ns>.svc.clusterset.local domain for a ClusterIP service should resolve to the "+
 		"clusterset IP", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")

--- a/conformance/connectivity.go
+++ b/conformance/connectivity.go
@@ -29,6 +29,10 @@ import (
 var _ = Describe("", func() {
 	t := newTestDriver()
 
+	BeforeEach(func() {
+		t.autoExportService = false
+	})
+
 	Context("Connectivity to a service that is not exported", func() {
 		It("should be inaccessible", Label(RequiredLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#exporting-services")

--- a/conformance/endpoint_slice.go
+++ b/conformance/endpoint_slice.go
@@ -34,10 +34,6 @@ const K8sEndpointSliceManagedByName = "endpointslice-controller.k8s.io"
 var _ = Describe("", Label(OptionalLabel, EndpointSliceLabel), func() {
 	t := newTestDriver()
 
-	JustBeforeEach(func() {
-		t.createServiceExport(&clients[0], newHelloServiceExport())
-	})
-
 	Specify("Exporting a service should create an MCS EndpointSlice in the service's namespace in each cluster with the "+
 		"required MCS labels. Unexporting should delete the EndpointSlice.", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#using-endpointslice-objects-to-track-endpoints")

--- a/conformance/headless_service_dns.go
+++ b/conformance/headless_service_dns.go
@@ -45,10 +45,6 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 		t.helloDeployment.Spec.Replicas = ptr.To(int32(replicas))
 	})
 
-	JustBeforeEach(func() {
-		t.createServiceExport(&clients[0], newHelloServiceExport())
-	})
-
 	Specify("A DNS query of the <service>.<ns>.svc.clusterset.local domain for a headless service should return the "+
 		"ready endpoint addresses of all the backing pods", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")


### PR DESCRIPTION
...in two cluster conformance tests. Previously, the tests exported the first cluster in JustBeforeEach but that was executed after the JustBeforeEach in the twoClusterTestDriver so the second cluster was actually exported first.